### PR TITLE
docs: fix stale claims about workflow extensibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ See [README.md](README.md) for the full feature list and value proposition.
 ## Project Structure
 
 ```
-clients/     # external API wrappers — one subdir per service
+clients/     # external API wrappers — one file (or subdirectory) per external service
 config/      # reads env vars into typed domain structs
 domain/      # types + pure logic; no I/O; no imports from other hub crates
 store/       # local SQLite reads/writes

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ prioritized view with agentic capabilities built in:
 - **Launch pad, not chat** — hub surfaces signals and launches Claude Code skills or
   autonomous agents preloaded with the right context; it leverages Claude Code rather than
   reinventing its interface; see [Decision 007](docs/decisions/007-tui-over-web-app.md)
-- **Extensible** — adding a new workflow = adding files to `clients/` and `workflows/`; no
-  registration step
+- **Extensible** — adding a new workflow follows a short, documented playbook spanning
+  `clients/`, `workflows/`, and `config/`; see [add a workflow](docs/playbooks/add-a-workflow.md)
 - **Local-only** — no server, no cloud sync; each device has its own SQLite database and
   runs independently
 - **Rust** — two binaries: `hub` (CLI) and `hub-tui` (Ratatui dashboard); not a web app


### PR DESCRIPTION
## ✅ What

- Fixes two stale claims about workflow extensibility in the top-level docs
- `AGENTS.md` project tree said `clients/` holds "one subdir per service", but `clients/src/` is flat (`github.rs`, `linear.rs`, `loki.rs` + the `private/` symlink); reworded to "one file (or subdirectory) per external service" to match `clients/README.md`
- `README.md` claimed adding a workflow needed "no registration step", but `docs/playbooks/add-a-workflow.md` lists explicit registration steps in `config/` (`WorkflowConfig` variant, rstest case, JSON schema entry, `hub.toml.example` entry, CLI wiring); reworded to point at the playbook instead of overpromising friction-free extension
- The issue comment also flagged the Stack table's SQLite claim as stale — that one is now accurate (`store/Cargo.toml` has had `rusqlite = { version = "0.31", features = ["bundled"] }` since commit 866f811), so left alone

## 🤔 Why

- A cold reader (human or agent) following `AGENTS.md` will create `clients/src/<service>/mod.rs` for a new client, contradicting the flat convention already in place
- The README's "no registration step" framing sets the wrong expectation for anyone planning a new workflow — they'll hit five registration steps they weren't told about

## 👩‍🔬 How to validate

- [ ] Read `AGENTS.md` line 14 and `clients/README.md` line 6 — expect both to describe the layout as either a file or a subdirectory per service
- [ ] List `clients/src/` — expect flat files (`github.rs`, `linear.rs`, `loki.rs`) plus the `private/` symlink, matching the new wording
- [ ] Read `README.md` lines 28–29 — expect a link to `docs/playbooks/add-a-workflow.md` rather than a "no registration step" claim
- [ ] Skim `docs/playbooks/add-a-workflow.md` — expect the registration steps listed there to be consistent with the new README phrasing

Closes #20
