### PR TITLE
docs/decisions: fix stale config/schemas/workflows reference

### DIFF
--- a/docs/decisions/003-config-model.md
+++ b/docs/decisions/003-config-model.md
@@ -90,8 +90,8 @@ name = "home-server-health"
 Workflow objects have `name` as the only required field. Everything beyond
 that is defined by the individual workflow implementation. The config parser
 passes the full object to the workflow; the workflow reads what it needs.
-Per-workflow schemas live in `config/schemas/workflows/` and document what each
-workflow accepts.
+Per-workflow object shapes live as `workflow_<name>` definitions in
+`config/schemas/hub.toml.schema.json` and document what each workflow accepts.
 
 ### Schema
 


### PR DESCRIPTION
## ✅ What

- Rewrites a stale line in ADR 003 so it describes where per-workflow schemas actually live
- Old line pointed at `config/schemas/workflows/`, a directory that does not exist
- New line points at the `workflow_<name>` definitions inside `config/schemas/hub.toml.schema.json` — where the shapes actually live today

## 🤔 Why

- An agent or human reading ADR 003 to find per-workflow schema docs would hunt for a directory that doesn't exist and waste time
- Picked rewriting the doc over creating the missing directory because the schema definitions already live in one well-organized place — splitting them across per-workflow files would add maintenance overhead with no payoff

## 👩‍🔬 How to validate

- [ ] Open `docs/decisions/003-config-model.md` and read the "Workflow config" subsection (around line 88)
- [ ] Expect the paragraph to reference `config/schemas/hub.toml.schema.json` and `workflow_<name>` definitions — no mention of `config/schemas/workflows/`
- [ ] Open `config/schemas/hub.toml.schema.json` and search for `workflow_`
- [ ] Expect to see definitions like `workflow_errors_gcp`, `workflow_github_ci`, …, `workflow_private` — confirming the ADR now describes the real layout
- [ ] Run `rg "config/schemas/workflows" .` from the repo root
- [ ] Expect no results

## 🔖 Related links

Closes #22
