### PR TITLE
docs: align private-workflows and ADR 002 with prompts terminology

### DIFF
--- a/docs/architecture/private-workflows.md
+++ b/docs/architecture/private-workflows.md
@@ -1,6 +1,6 @@
-# Private Workflows and Skills
+# Private Workflows and Prompts
 
-Hub is a public repo. Some workflows and investigation skills connect to systems you may not
+Hub is a public repo. Some workflows and investigation prompts connect to systems you may not
 want to name publicly (e.g. confidential work stuff) — those live in a separate private repo
 (`hub-private`) that gets wired into this workspace via symlinks and a Cargo feature flag.
 
@@ -14,7 +14,7 @@ want to name publicly (e.g. confidential work stuff) — those live in a separat
     workflows/src/   ← private workflows + PrivateStatusData types
     ui/cli/src/      ← private CLI rendering logic
     ui/tui/src/      ← private TUI rendering logic
-    .claude/skills/  ← private investigation skills
+    prompts/         ← private investigation prompts
     devices/         ← per-device configuration
       home-laptop.toml
       work-laptop.toml

--- a/docs/decisions/002-public-repo-private-integrations.md
+++ b/docs/decisions/002-public-repo-private-integrations.md
@@ -15,22 +15,22 @@ on employer policies.
 
 ## Decision
 
-Hub is a public repo. Sensitive workflows and investigation skills live in a
+Hub is a public repo. Sensitive workflows and investigation prompts live in a
 private companion repo (`hub-private`) and are symlinked into gitignored
 directories in hub:
 
 ```
 hub/clients/src/private/   →  symlink  →  hub-private/clients/src/
 hub/workflows/src/private/  →  symlink  →  hub-private/workflows/src/
-hub/.claude/skills/<name>.md  →  symlink  →  hub-private/.claude/skills/<name>.md
+hub/prompts/<name>.md  →  symlink  →  hub-private/prompts/<name>.md
 ```
 
 `hub-private` is a private GitHub repo with the same owner. It is cloned
 alongside hub on each device and linked via a setup script. This keeps
-sensitive workflows and skills version-controlled and recoverable without ever
+sensitive workflows and prompts version-controlled and recoverable without ever
 appearing in hub's public history.
 
-The public repo shows only workflows and skills appropriate to share: GitHub,
+The public repo shows only workflows and prompts appropriate to share: GitHub,
 Linear, Loki, Datadog, and similar professional tooling. The private
 equivalents are invisible to the public codebase but fully functional
 locally.


### PR DESCRIPTION
## ✅ What

- Brings two docs in line with reality after the skills→prompts migration: the `private-workflows.md` directory tree and ADR 002's symlink diagram both still claimed private extensions live in `hub-private/.claude/skills/`, a path that has never existed
- Replaces those references with the layout that actually works today — `hub-private/prompts/` symlinked individually into `hub/prompts/` — matching what `scripts/setup-private.sh` already does
- No code changes; the playbook the original issue pointed at (`add-a-skill.md`) was already deleted in a942cef when skills were replaced with prompts

## 🤔 Why

- A contributor reading the docs cold was being told to put private skills in a directory that doesn't exist and isn't wired up by the setup script — they would stall with no signal about what's wrong
- ADRs and architecture docs are the load-bearing reference for "where does this go" decisions; leaving them stale makes every future private addition slower to land

## 👩‍🔬 How to validate

- [ ] Read `docs/architecture/private-workflows.md` top to bottom
- [ ] Expect the title, intro, and directory tree to all say "prompts" (no remaining "skills" references in the private-extension context)
- [ ] Expect the body around lines 43–47 (about individually symlinked private prompts) to be consistent with the directory tree
- [ ] Read `docs/decisions/002-public-repo-private-integrations.md`
- [ ] Expect the symlink diagram to show `hub/prompts/<name>.md  →  symlink  →  hub-private/prompts/<name>.md`
- [ ] Expect the surrounding prose to say "workflows and prompts" rather than "workflows and skills"
- [ ] Open `scripts/setup-private.sh` and find the `link "$HUB_PRIVATE/prompts/..."` call on line 96 — confirm the ADR's diagram matches what the script actually does

## 🔖 Related links

- https://github.com/ooloth/hub/issues/24

Closes #24
