### PR TITLE
Assert `items[group_index]` is a `Group` variant in `apply_enter_action`

### DIFF
--- a/ui/tui/src/state/update.rs
+++ b/ui/tui/src/state/update.rs
@@ -294,6 +294,10 @@ impl App {
                     selected: *selected,
                     filter: filter.clone(),
                 };
+                assert!(
+                    matches!(items.get(group_index), Some(DisplayItem::Group { .. })),
+                    "group_index must point to a Group variant"
+                );
                 let mut ds = ListState::default();
                 if item_count > 0 {
                     ds.select(Some(0));


### PR DESCRIPTION
Adds an assertion in `apply_enter_action` before transitioning to `Screen::Detail` so that if `group_index` ever points to a non-`Group` `DisplayItem`, the bug surfaces immediately at the transition site rather than producing silent incorrect reads scattered across the detail screen.

Closes #47

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWPHUTNZkL6Ww9RungK9Hg)_