### PR TITLE
fix(CONTRIBUTING): correct just check comment to reflect fmt + lint behavior

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ for the full model, how to add new devices, and how to add new private workflows
 ## Running
 
 ```bash
-just check              # verify workspace compiles
+just check              # fmt + lint (autofixes where possible)
 just status             # run with secrets injected
 ```
 


### PR DESCRIPTION
## Summary

- The inline comment next to `just check` in `CONTRIBUTING.md` said "verify workspace compiles" but the recipe actually runs `taplo fmt`, `taplo check`, `cargo fmt`, and `cargo clippy --fix` — formatting and linting with autofixes, not a compile check.
- Updated the comment to "fmt + lint (autofixes where possible)" to match the actual recipe behavior and align with how `CLAUDE.md` already describes it.

## Test plan

- [ ] Read `CONTRIBUTING.md` lines 51–57 — the comment next to `just check` should describe formatting and linting, not compiling.
- [ ] Run `just check` in a clean working tree — confirm it runs `taplo fmt`, `cargo fmt`, and `cargo clippy --fix` as described.

Closes #63

## Related Links

- https://claude.ai/code/session_01JXbwWw7vxy9GW3wSh9Swi3