### PR TITLE
clients: replace lifetime-annotated Request with owned String field

### DIFF
--- a/clients/src/linear.rs
+++ b/clients/src/linear.rs
@@ -4,8 +4,8 @@ use domain::{LinearIssue, Urgency};
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize)]
-struct Request<'a> {
-    query: &'a str,
+struct Request {
+    query: String,
 }
 
 #[derive(Deserialize)]
@@ -55,7 +55,7 @@ pub async fn issues(token: &str) -> Result<Vec<LinearIssue>> {
     let resp = reqwest::Client::new()
         .post("https://api.linear.app/graphql")
         .header("Authorization", token)
-        .json(&Request { query })
+        .json(&Request { query: query.to_string() })
         .send()
         .await
         .context("failed to reach Linear API")?;

--- a/clients/src/linear.rs
+++ b/clients/src/linear.rs
@@ -55,7 +55,9 @@ pub async fn issues(token: &str) -> Result<Vec<LinearIssue>> {
     let resp = reqwest::Client::new()
         .post("https://api.linear.app/graphql")
         .header("Authorization", token)
-        .json(&Request { query: query.to_string() })
+        .json(&Request {
+            query: query.to_string(),
+        })
         .send()
         .await
         .context("failed to reach Linear API")?;


### PR DESCRIPTION
## ✅ What

- Replaces `&'a str` with `String` in the `Request` struct in `clients/src/linear.rs`, removing its lifetime parameter entirely
- Calls `.to_string()` at the single construction site

## 🤔 Why

- The lifetime annotation on `Request` forced callers to ensure the query string outlived the struct, adding hidden constraints that resist refactoring
- The struct is constructed and immediately serialized — it has no reason to borrow; owning is the right choice

## 👩‍🔬 How to validate

- [ ] Open `clients/src/linear.rs` and expect `struct Request { query: String }` with no `'a` lifetime parameter
- [ ] Search the file for `Request {` and expect the construction site to use `.to_string()`
- [ ] Run `cargo check` from the workspace root and expect zero errors

## 🔖 Related links

- https://github.com/ooloth/hub/issues/67
- https://claude.ai/code/

Closes #67

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwQ3AFcGPyDXyuXLqTTeYE)_