### PR TITLE
claude: remove external rust.md reference from Rust Conventions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,8 +51,6 @@ do not depend on `config/` directly.
 
 ### Rust Conventions
 
-See `~/.claude/references/rust.md` and `~/.claude/references/type-design.md`.
-
 Hard rules for agents:
 
 - **Error handling**: `anyhow` only. No `thiserror`. `?` everywhere. `.context("msg")` for human-readable chains.


### PR DESCRIPTION
## What

- Removes the `See ~/.claude/references/rust.md and ~/.claude/references/type-design.md` line from the Rust Conventions section — the critical rules were already inlined under "Hard rules for agents", so the deferral line was the only missing piece

## Why

- Agents running without the dotfiles repo (CI, remote sessions, fresh machines) had no access to the external rust.md and would miss the Rust conventions entirely
- All four rules the issue requires (no lifetime annotations, clone freely, anyhow only, owned String fields) were already present inline — only the external reference needed removing

## How to validate

- [ ] Open `CLAUDE.md` and search for "lifetime" — expect to find the rule prohibiting lifetime annotations
- [ ] Search for "clone" — expect to find the rule permitting cloning over borrowing
- [ ] Search for "anyhow" — expect to find the rule restricting error handling to anyhow
- [ ] Search for `~/.claude/references/rust` — expect no results

## Related links

- Closes #90
- https://claude.ai/code/session_01NX6Sqy1LRifn2ZbMjm4gcM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NX6Sqy1LRifn2ZbMjm4gcM)_