### PR TITLE
claude: add inline purpose statement to CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ If `../hub-private/CLAUDE.md` exists, read it before writing or editing any file
 
 ## What This Is
 
-Hub is a personal command-line status dashboard that aggregates signals from multiple sources — GitHub PRs, CI status, Loki alerts, Linear tasks, media health — into a single urgency-ranked terminal view. Its two binaries are `hub` (CLI) and `hub-tui` (Ratatui dashboard). The core value is cross-domain triage: signals from different systems are compared in one prioritized list, and a keypress on any item opens the right Claude Code skill pre-loaded with context so investigation starts immediately.
+Hub is a personal command-line status dashboard that aggregates signals from multiple sources — GitHub PRs, CI status, Loki alerts, Linear issues, and more via the `private` feature — into a single urgency-ranked terminal view. Its two binaries are `hub` (CLI) and `hub-tui` (Ratatui dashboard). The core value is cross-domain triage: signals from different systems are compared in one prioritized list, and a keypress on supported items opens the right Claude Code skill pre-loaded with context so investigation starts immediately.
 
 See [README.md](README.md) for the full feature list and value proposition.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ If `../hub-private/CLAUDE.md` exists, read it before writing or editing any file
 
 ## What This Is
 
+Hub is a personal command-line status dashboard that aggregates signals from multiple sources — GitHub PRs, CI status, Loki alerts, Linear tasks, media health — into a single urgency-ranked terminal view. Its two binaries are `hub` (CLI) and `hub-tui` (Ratatui dashboard). The core value is cross-domain triage: signals from different systems are compared in one prioritized list, and a keypress on any item opens the right Claude Code skill pre-loaded with context so investigation starts immediately.
+
 See [README.md](README.md) for the full feature list and value proposition.
 
 ## Project Structure


### PR DESCRIPTION
## What

- Adds an inline paragraph to the `## What This Is` section of `AGENTS.md` / `CLAUDE.md` describing what hub is, what signals it aggregates, and why it exists — no link-following required
- The existing link to `README.md` is kept for deeper detail

## Why

- An agent reading `CLAUDE.md` to orient itself encountered only a link to `README.md`, requiring an extra file read before knowing what hub is or why it exists
- The inline summary makes `CLAUDE.md` self-contained for orientation

## How to validate

- [ ] Open `AGENTS.md` (or `CLAUDE.md` — they are symlinked) and read the `## What This Is` section
- [ ] Expect to see at least one sentence describing what hub is and what problem it solves, without needing to open `README.md`
- [ ] Cross-reference the summary with `README.md` — expect it to be accurate

## Related links

Closes #65

https://claude.ai/code/session_01NX6Sqy1LRifn2ZbMjm4gcM

---
_Generated by [Claude Code](https://claude.ai/code/session_01NX6Sqy1LRifn2ZbMjm4gcM)_