### PR TITLE
fix stale CLI README example and clippy dead-code CI failure

### DIFF
--- a/ui/cli/README.md
+++ b/ui/cli/README.md
@@ -18,7 +18,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
-    Sync { slug: Option<String> },
+    Fetch,
     Status,
 }
 

--- a/ui/tui/src/investigations/mod.rs
+++ b/ui/tui/src/investigations/mod.rs
@@ -33,7 +33,7 @@ pub(crate) enum WorktreeSpec {
     /// `project` is the directory name under `~/.hub/repos/`.
     Ephemeral { project: String },
     /// Use the process's current directory (MediaBlocked, last-resort fallback).
-    #[allow(dead_code)]
+    #[cfg(feature = "private")]
     CurrentDir,
 }
 
@@ -224,6 +224,7 @@ async fn resolve_worktree(
             );
             Ok((worktree, Some(cleanup)))
         }
+        #[cfg(feature = "private")]
         WorktreeSpec::CurrentDir => {
             let cwd = std::env::current_dir().context("Cannot determine working directory")?;
             Ok((cwd, None))


### PR DESCRIPTION
## ✅ What

- Fixes two small issues on the `claude/issue-57` branch: a stale CLI README example and a clippy dead-code warning that fails CI
- Updates the `Commands` enum example in `ui/cli/README.md` to match the actual enum — replaces the nonexistent `Sync { slug: Option<String> }` variant with `Fetch`
- Gates `WorktreeSpec::CurrentDir` behind `#[cfg(feature = "private")]` to match its only call site, which is already private-gated

## 🤔 Why

- The CLI README is the primary reference for adding new commands — a stale example showing a variant that doesn't exist will mislead contributors
- `CurrentDir` is only used by the `MediaBlocked` investigation (private feature), so without the gate clippy reports dead code and CI fails with `-D warnings`

## 👩‍🔬 How to validate

- [ ] Open `ui/cli/README.md` and read the `Commands` enum example — expect to see `Fetch` and `Status` variants with no struct fields
- [ ] Search the README for `Sync` and `slug` — expect zero matches
- [ ] Open `ui/cli/src/main.rs` lines 15–19 — expect the example to match
- [ ] Check that CI passes (the clippy dead-code error should be gone)

## 🔖 Related links

- https://github.com/ooloth/hub/issues/57

Closes #57
