### PR TITLE
docs: add cargo-nextest to CONTRIBUTING prerequisites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,7 @@
 - [1Password CLI](https://developer.1password.com/docs/cli) — `brew install 1password-cli`
 - [taplo](https://taplo.tamasfe.dev) — `brew install taplo` (TOML formatter and schema validator)
 - [prek](https://github.com/j178/prek) — `brew install prek` (git hook manager)
+- [cargo-nextest](https://nexte.st) — `cargo install cargo-nextest --locked` (test runner)
 
 ## Setup
 


### PR DESCRIPTION
## ✅ What

- Adds `cargo-nextest` to the Prerequisites section of `CONTRIBUTING.md` with its install command

## 🤔 Why

- `just test` runs `cargo nextest run`, but `cargo-nextest` wasn't listed as a prerequisite — an agent or developer setting up the repo for the first time would hit `cargo: no such subcommand: nextest` with no clear path forward

## 👩‍🔬 How to validate

- [ ] Open `CONTRIBUTING.md` — expect `cargo-nextest` listed in the Prerequisites section
- [ ] Expect an install command (`cargo install cargo-nextest --locked`) to be shown alongside it

## 🔖 Related links

- https://github.com/ooloth/hub/issues/92

Closes #92

---
_Generated by [Claude Code](https://claude.ai/code/session_01MsMseG9JcQa1jPW11PKCcY)_